### PR TITLE
Refactor: A post can be asociated to a parent post

### DIFF
--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,4 +1,0 @@
-class Comment < ApplicationRecord
-  belongs_to :user
-  belongs_to :post
-end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -9,7 +9,25 @@ class Post < ApplicationRecord
   has_many_attached :images
   has_many :shared_posts_relation, class_name: 'SharedPost', foreign_key: :post_id
   has_many :sharers, through: :shared_posts_relation, source: :user
-  has_many :comments
-  has_many_attached :images
+  
+ 
   has_many :likes
+
+  # Associate a post as to a parent post
+  # this allows to treat it as a comment when needed
+  belongs_to :parent, class_name: 'Post', optional: true
+
+  # Get the posts that belongs to another post
+  scope :comments, ->(post) { where(parent_id: post.id) }
+
+  # Recursivelly calls all the parents/ancestors
+  scope :ancestors, ->(post, ancestors_list) {
+    if post.parent.nil?
+      return ancestors_list
+    else
+      ancestors_list.unshift(post.parent)
+    end
+    ancestors(post.parent, ancestors_list)
+  }
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,6 @@ class User < ApplicationRecord
   has_one_attached :banner
   
   has_many :posts
-  has_many :comments
   has_many :followed_users, foreign_key: :follower_id, class_name: 'Follow'
   has_many :following_users, foreign_key: :following_id, class_name: 'Follow'
   has_many :followings, through: :followed_users, source: :following

--- a/db/migrate/20230801221205_create_posts.rb
+++ b/db/migrate/20230801221205_create_posts.rb
@@ -4,8 +4,12 @@
 class CreatePosts < ActiveRecord::Migration[7.0]
   def change
     create_table :posts do |t|
-      t.text :context
+      t.text :content
 
+      t.references :user, null: false, foreign_key: true
+
+      t.references :parent, foreign_key: { to_table: :posts }
+  
       t.timestamps
     end
   end

--- a/db/migrate/20230801221305_add_user_reference_to_post.rb
+++ b/db/migrate/20230801221305_add_user_reference_to_post.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Add user reference to post
-class AddUserReferenceToPost < ActiveRecord::Migration[7.0]
-  def change
-    add_reference :posts, :user, null: false, foreign_key: true
-  end
-end

--- a/db/migrate/20230801234505_change_field_name_in_table_post.rb
+++ b/db/migrate/20230801234505_change_field_name_in_table_post.rb
@@ -1,8 +1,0 @@
-# frozen_string_literal: true
-
-# Change field name in table post
-class ChangeFieldNameInTablePost < ActiveRecord::Migration[7.0]
-  def change
-    rename_column :posts, :context, :content
-  end
-end

--- a/db/migrate/20230808031835_create_comments.rb
+++ b/db/migrate/20230808031835_create_comments.rb
@@ -1,9 +1,0 @@
-class CreateComments < ActiveRecord::Migration[7.0]
-  def change
-    create_table :comments do |t|
-      t.text :content
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20230808032142_add_user_references_to_comment.rb
+++ b/db/migrate/20230808032142_add_user_references_to_comment.rb
@@ -1,5 +1,0 @@
-class AddUserReferencesToComment < ActiveRecord::Migration[7.0]
-  def change
-    add_reference :comments, :user, null: false, foreign_key: true
-  end
-end

--- a/db/migrate/20230808032214_add_post_references_to_comment.rb
+++ b/db/migrate/20230808032214_add_post_references_to_comment.rb
@@ -1,5 +1,0 @@
-class AddPostReferencesToComment < ActiveRecord::Migration[7.0]
-  def change
-    add_reference :comments, :post, null: false, foreign_key: true
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,16 +42,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_235147) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
-  create_table "comments", force: :cascade do |t|
-    t.text "content"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
-    t.bigint "post_id", null: false
-    t.index ["post_id"], name: "index_comments_on_post_id"
-    t.index ["user_id"], name: "index_comments_on_user_id"
-  end
-
   create_table "follows", force: :cascade do |t|
     t.integer "follower_id"
     t.integer "following_id"
@@ -70,9 +60,11 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_235147) do
 
   create_table "posts", force: :cascade do |t|
     t.text "content"
+    t.bigint "user_id", null: false
+    t.bigint "parent_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id", null: false
+    t.index ["parent_id"], name: "index_posts_on_parent_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
 
@@ -103,10 +95,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_235147) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "comments", "posts"
-  add_foreign_key "comments", "users"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "posts", "posts", column: "parent_id"
   add_foreign_key "posts", "users"
   add_foreign_key "shared_posts", "posts"
   add_foreign_key "shared_posts", "users"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,17 @@
 # frozen_string_literal: true
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-    posts = Post.create([{content: "This is the first post", user_id: 1}])
-#   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
-#   Character.create(name: "Luke", movie: movies.first)
+
+users = User.create([
+    { name: "Aaa Aaa", username: "a", email: "a@a.a", password: "123456" },
+    { name: "Bbb Bbb", username: "b", email: "b@b.b", password: "123456" },
+])
+
+posts = Post.create([
+    #Posts
+    { content: "This is the first post", user_id: 1 },
+    { content: "This is the second post", user_id: 1 },
+
+    # Comments
+    { content: "Comment on post 1", user_id: 1, parent_id: 1 },
+    { content: "Comment on comment post 1", user_id: 2, parent_id: 3 },
+    { content: "Comment on comment on comment post 1", user_id: 1, parent_id: 4 },
+])

--- a/test/fixtures/comments.yml
+++ b/test/fixtures/comments.yml
@@ -1,7 +1,0 @@
-# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-one:
-  content: MyText
-
-two:
-  content: MyText

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class CommentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class PostTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "the truth" do
+    assert true
+  end
 end


### PR DESCRIPTION
## Description
A post can be associated to a parent post.

### What:
I've deleted the comment model and its dependent entities.
I've added the parent association to the post model.
I've added a method that collects all the posts sharing the same parent (The comments)
I've added a recursive method that collects all the posts which are parents of a post (Ancestors)

### Why:
A comment needs to be a post in order to have the same features, such as Likes, or have more comments.
The view has to show the "ancestors" before the current post to visualize a thread of messages.

## Testing
Seeds
```ruby
Post.create([
    #Posts
    { content: "This is the first post", user_id: 1 },
    { content: "This is the second post", user_id: 1 },
    # Comments
    { content: "Comment on post 1", user_id: 1, parent_id: 1 },
    { content: "Comment on comment post 1", user_id: 2, parent_id: 3 },
    { content: "Comment on comment on comment post 1", user_id: 1, parent_id: 4 },
])
```
Based on the previous seeds, by executing the following commands in the console, it will show the list of comments or ancestors.
```ruby
first = Post.where(id: 1).first
Post.comments(first)                # It will show comments
Post.ancestors(first, [])           # It will show no parent

fifth = Post.where(id: 5).first
Post.ancestors(fifth, [])           # It will show parents
Post.comments(fifth)                # It will show no comments



```