### PR TITLE
Feat/delete account

### DIFF
--- a/app/assets/stylesheets/app.scss
+++ b/app/assets/stylesheets/app.scss
@@ -5,7 +5,8 @@
   "./sass/home",
   "./sass/posts",
   "./sass/registrations",
-  "./sass/new_post";
+  "./sass/new_post",
+  "./sass/settings";
 
 * {
   margin: 0;

--- a/app/assets/stylesheets/sass/abstracts/colors.scss
+++ b/app/assets/stylesheets/sass/abstracts/colors.scss
@@ -7,3 +7,4 @@ $colorBlue: #28f;
 $colorGray: #888;
 $colorBorder: #2e3139;
 $colorDarkMint: #23484B;
+$colorDarkRed: #2a0a0a;

--- a/app/assets/stylesheets/sass/settings.scss
+++ b/app/assets/stylesheets/sass/settings.scss
@@ -1,0 +1,14 @@
+.delete-button {
+  background-color: $colorDarkRed;
+  border: none;
+  color: $colorRed;
+  cursor: pointer;
+  padding: 1rem;
+  width: 100%;
+
+  &:hover {
+    background-color: lighten($colorDarkRed, 5%);
+    color: lighten($colorRed, 5%);
+  }
+
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -45,15 +45,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
       
       current_user.follower_records.destroy_all
       current_user.swap_posts_to_deleted_user
-
-      puts "=" * 30
-      puts current_user.posts.first.inspect
-
       current_user.destroy
     end
 
-    # if 
-    # end
+    redirect_to root_path
   end
 
   protected

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -39,6 +39,23 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @user = User.find(params[:id])
   end
 
+  def destroy
+    User.transaction do
+      DeletedUser.create(id: current_user.id, username: current_user.username)
+      
+      current_user.follower_records.destroy_all
+      current_user.swap_posts_to_deleted_user
+
+      puts "=" * 30
+      puts current_user.posts.first.inspect
+
+      current_user.destroy
+    end
+
+    # if 
+    # end
+  end
+
   protected
 
   # If you have extra params to permit, append them to the sanitizer.

--- a/app/controllers/users/settings_controller.rb
+++ b/app/controllers/users/settings_controller.rb
@@ -1,0 +1,5 @@
+class Users::SettingsController < ApplicationController
+  
+  def index; end
+
+end

--- a/app/helpers/users/settings_helper.rb
+++ b/app/helpers/users/settings_helper.rb
@@ -1,0 +1,2 @@
+module Users::SettingsHelper
+end

--- a/app/models/deleted_user.rb
+++ b/app/models/deleted_user.rb
@@ -1,0 +1,3 @@
+class DeletedUser < ApplicationRecord
+  has_many :posts
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -4,7 +4,8 @@
 class Post < ApplicationRecord
   validates :content, presence: true
 
-  belongs_to :user
+  belongs_to :user, optional: true
+  belongs_to :deleted_user, optional: true
 
   has_many_attached :images
   has_many :shared_posts_relation, class_name: 'SharedPost', foreign_key: :post_id
@@ -37,5 +38,11 @@ class Post < ApplicationRecord
     end
     ancestors(post.parent, ancestors_list)
   }
+
+  def swap_to_deleted_user(deleted_id)
+    self.user_id = nil
+    self.deleted_user_id = deleted_id
+    save
+  end
 
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@ class User < ApplicationRecord
   has_one_attached :banner
   
   # Post relationship
-  has_many :posts
+  has_many :posts #, dependant: :nullify??
   def posts_number
     posts.count
   end
@@ -37,4 +37,11 @@ class User < ApplicationRecord
 
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  def swap_posts_to_deleted_user
+    posts.each do |post|
+      post.swap_to_deleted_user(id)
+    end
+  end
+  
 end

--- a/app/views/devise/registrations/avatar.html.erb
+++ b/app/views/devise/registrations/avatar.html.erb
@@ -12,7 +12,7 @@
 
         <%= form.label :avatar , class: "avatar-label" do %>
           <i class="fa-solid fa-camera signup-camera"></i>
-          <i class="fa-solid fa-user signup-avatar signup-avatar-icon" data-signup-avatar-target="icon"></i>
+          <i class="fa-solid fa-cloud signup-avatar signup-avatar-icon" data-signup-avatar-target="icon"></i>
           <img src="#" class="signup-avatar hidden" data-signup-avatar-target="image"></img>
         <% end %>
 

--- a/app/views/posts/_parent.html.erb
+++ b/app/views/posts/_parent.html.erb
@@ -1,31 +1,36 @@
 <div class="post <%= !is_parent_of_comment && "border-post" %> parent-post-container">
 
-  <%= render partial: "posts/simple-post-left", locals: { post: post , from_parent: true } %>
+  <% if post.user %>
+    
+    <%= render partial: "posts/simple-post-left", locals: { post: post , from_parent: true } %>
 
-  <div class="parent-post-right">
+    <div class="parent-post-right">
 
-    <% locals_metadata = { 
-      post: post, 
-      is_current_post: false, 
-      is_parent_of_comment: is_parent_of_comment,
-      view: :show 
-    } %>
-    <%= render partial: "posts/components/metadata" , locals: locals_metadata %>    
+      <% locals_metadata = { 
+        post: post, 
+        is_current_post: false, 
+        is_parent_of_comment: is_parent_of_comment,
+        view: :show 
+      } %>
+      <%= render partial: "posts/components/metadata" , locals: locals_metadata %>    
 
-    <%= render partial: "posts/components/content" , locals: { post: post }%>
+      <%= render partial: "posts/components/content" , locals: { post: post }%>
 
-    <% if is_parent_of_comment %>
-      <div>
-        Replying to
-        <%= link_to("") do %>
-          @<%= post.user.username %>
-        <% end %>
-      </div>
-    <% else %>
-      <%= render partial: "posts/components/actions" , locals: { post: post }%>
-    <% end %>
-
-  </div>
+      <% if is_parent_of_comment %>
+        <div>
+          Replying to
+          <%= link_to("") do %>
+            @<%= post.user.username %>
+          <% end %>
+        </div>
+      <% else %>
+        <%= render partial: "posts/components/actions" , locals: { post: post }%>
+      <% end %>
+    </div>
+    
+  <% elsif post.deleted_user %>
+    This post is not available anymore
+  <% end %>
 
 </div>
 

--- a/app/views/posts/_post-simple.html.erb
+++ b/app/views/posts/_post-simple.html.erb
@@ -1,15 +1,18 @@
 <div class="post border-post parent-post-container">
 
-  <%= render partial: "posts/simple-post-left", locals: { post: post , from_parent: false } %>
+  <% if post.user %>
+  
+    <%= render partial: "posts/simple-post-left", locals: { post: post , from_parent: false } %>
 
-  <div class="parent-post-right">
+    <div class="parent-post-right">
+      <% locals_metadata = { post: post, is_current_post: false, is_parent_of_comment: false, view: view } %>
+      <%= render partial: "posts/components/metadata", locals: locals_metadata %>
+      <%= render partial: "posts/components/content" , locals: { post: post }%>
+      <%= render partial: "posts/components/actions" , locals: { post: post }%>
+    </div>
 
-    <% locals_metadata = { post: post, is_current_post: false, is_parent_of_comment: false, view: view } %>
-    <%= render partial: "posts/components/metadata", locals: locals_metadata %>
-
-    <%= render partial: "posts/components/content" , locals: { post: post }%>
-    <%= render partial: "posts/components/actions" , locals: { post: post }%>
-
-  </div>
-
+  <% elsif post.deleted_user %>
+    This post is not available anymore
+  <% end %>
+  
 </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,25 +1,29 @@
 <div class="post current-post">
 
-  <div class="post-header">
+  <% if post.user %>
+  
+    <div class="post-header">
+      <%= render partial: "posts/components/avatar" , locals: { avatar: post.user.avatar }%>
 
-    <%= render partial: "posts/components/avatar" , locals: { avatar: post.user.avatar }%>
+      <% locals_metadata = { post: post, is_current_post: is_current_post, is_parent_of_comment: false, view: view } %>
+      <%= render partial: "posts/components/metadata" , locals: locals_metadata %>
+    </div>
 
-    <% locals_metadata = { post: post, is_current_post: is_current_post, is_parent_of_comment: false, view: view } %>
-    <%= render partial: "posts/components/metadata" , locals: locals_metadata %>
-    
-  </div>
+    <%= render partial: "posts/components/content" , locals: { post: post }%>
 
-  <%= render partial: "posts/components/content" , locals: { post: post }%>
-
-  <div class="post-time-bottom post-meta">
-    <% if view == :index %>
+    <div class="post-time-bottom post-meta">
+      <% if view == :index %>
       <%= format_time_ago(post.created_at) %>
-    <% else %>
+      <% else %>
       <%= post.created_at.strftime("%-I:%M %p · %-d %b. %Y") %>
-    <% end %>
-  </div>
+      <% end %>
+    </div>
 
-  <hr />
-  <%= render partial: "posts/components/actions" , locals: { post: post }%>
+    <hr />
+    <%= render partial: "posts/components/actions" , locals: { post: post }%>
+
+  <% elsif post.deleted_user %>
+    This post is not available anymore 
+  <% end %>
 
 </div>

--- a/app/views/posts/_simple-post-left.html.erb
+++ b/app/views/posts/_simple-post-left.html.erb
@@ -1,5 +1,5 @@
 <div class="parent-post-left">
-  <%= render partial: "posts/components/avatar" , locals: { avatar: post.user.avatar }%>
+  <%= render partial: "posts/components/avatar" , locals: { avatar: post.user.avatar } %>
   <% if from_parent %>
     <span class="thread-line"></span>
   <% else %>

--- a/app/views/users/settings/_delete_account.html.erb
+++ b/app/views/users/settings/_delete_account.html.erb
@@ -1,0 +1,7 @@
+<%= button_to(user_registration_path,
+              method: :delete,
+              data: { turbo_confirm: "Are yout sure you want to delete this account?" },
+              class: 'delete-button') do %>
+
+  Delete Account
+<% end %>

--- a/app/views/users/settings/index.html.erb
+++ b/app/views/users/settings/index.html.erb
@@ -1,0 +1,3 @@
+<h1>Settings</h1>
+
+<%= render partial: 'delete_account' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,6 @@ Rails.application.routes.draw do
   resources :follows
   resources :posts
 
+  get '/settings', to: 'users/settings#index', as: 'settings'
+
 end

--- a/db/migrate/20230801001600_create_deleted_users.rb
+++ b/db/migrate/20230801001600_create_deleted_users.rb
@@ -1,0 +1,9 @@
+class CreateDeletedUsers < ActiveRecord::Migration[7.0]
+  def change
+    create_table :deleted_users do |t|
+      t.string :username
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230801221205_create_posts.rb
+++ b/db/migrate/20230801221205_create_posts.rb
@@ -6,7 +6,8 @@ class CreatePosts < ActiveRecord::Migration[7.0]
     create_table :posts do |t|
       t.text :content
 
-      t.references :user, null: false, foreign_key: true
+      t.references :user, null: true, foreign_key: true
+      t.references :deleted_user, null: true, foreign_key: true
 
       t.references :parent, foreign_key: { to_table: :posts }
   

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_235147) do
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
   end
 
+  create_table "deleted_users", force: :cascade do |t|
+    t.string "username"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "follows", force: :cascade do |t|
     t.integer "follower_id"
     t.integer "following_id"
@@ -60,10 +66,12 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_235147) do
 
   create_table "posts", force: :cascade do |t|
     t.text "content"
-    t.bigint "user_id", null: false
+    t.bigint "user_id"
+    t.bigint "deleted_user_id"
     t.bigint "parent_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["deleted_user_id"], name: "index_posts_on_deleted_user_id"
     t.index ["parent_id"], name: "index_posts_on_parent_id"
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
@@ -97,6 +105,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_08_10_235147) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "likes", "posts"
   add_foreign_key "likes", "users"
+  add_foreign_key "posts", "deleted_users"
   add_foreign_key "posts", "posts", column: "parent_id"
   add_foreign_key "posts", "users"
   add_foreign_key "shared_posts", "posts"

--- a/test/controllers/users/settings_controller_test.rb
+++ b/test/controllers/users/settings_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Users::SettingsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/deleted_users.yml
+++ b/test/fixtures/deleted_users.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  username: MyString
+
+two:
+  username: MyString

--- a/test/models/deleted_user_test.rb
+++ b/test/models/deleted_user_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class DeletedUserTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
# An account can be deleted

### What:
- I've created the route for settings
- I've added the view of settings to place the delete option
- I've created a model for deleted users
- I've configured the controller for assure a deletion and swapping to the new table

### Why:
- This feature is needed when a user doesn't want an account anymore
- A new model for deleted users is useful for maintaining the references of other posts such as comments or reposts and allow the user to create a new account with the same email or username without interfering with the deleted account. The references on the original table are swapped to the new one.

## Screenshots

### Delete button
![image](https://github.com/BrightCoders-Institute/proyecto-final-bcmay23-ror-team1/assets/42705523/fb1ac963-c205-4d9e-8f4e-f8fe826d079e)

### Unavailable posts, available parents or comments
![image](https://github.com/BrightCoders-Institute/proyecto-final-bcmay23-ror-team1/assets/42705523/4564ccb6-4d6c-4436-99e9-235368191d59)
