### PR TITLE
Fix: modified scroll-bar in full-container

### DIFF
--- a/app/assets/stylesheets/sass/login.scss
+++ b/app/assets/stylesheets/sass/login.scss
@@ -4,8 +4,12 @@
   flex-direction: column;
   height: 100vh;
   justify-content: center;
-  overflow: scroll;
   width: 100vw;
+  background-color: red;
+}
+
+.full-container::-webkit-scrollbar{
+  width: 0px;
 }
 
 .sigin-form {


### PR DESCRIPTION
## What
The full-container class in login.scss file was changed on its scroll-bar pseudo element overriding its width

## Screnshots
### After
![image](https://github.com/BrightCoders-Institute/proyecto-final-bcmay23-ror-team1/assets/65278575/45cf67f5-cf01-4588-ac98-56dcf6afda26)
### Before
![image](https://github.com/BrightCoders-Institute/proyecto-final-bcmay23-ror-team1/assets/65278575/1e3c1c21-e5af-42a8-bc62-6f264b49a703)